### PR TITLE
Fix bg mouse follow snippet

### DIFF
--- a/.obsidian/snippets/Archive/bg_mouse_follow.js
+++ b/.obsidian/snippets/Archive/bg_mouse_follow.js
@@ -6,9 +6,4 @@ document.addEventListener('mousemove', (e) => {
 
   document.body.style.setProperty('--bg-x', `${x * resistance}px`);
   document.body.style.setProperty('--bg-y', `${y * resistance}px`);
-
-  const before = document.querySelector('body::before');
-  if (before) {
-    before.style.transform = `translate(${x * resistance}px, ${y * resistance}px)`;
-  }
 });


### PR DESCRIPTION
## Summary
- remove body::before logic from `bg_mouse_follow.js`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684206edb3848322a7e61f6265255346