### PR TITLE
Update vault-mapper to use CLI arg

### DIFF
--- a/Vault/System/Backend/Scripts/Vault Mapping/vault-mapper.py
+++ b/Vault/System/Backend/Scripts/Vault Mapping/vault-mapper.py
@@ -2,9 +2,17 @@ import os
 import yaml
 import re
 import csv
+import argparse
 
-# Define the path to the vault
-vault_path = "path/to/your/vault"  # ← CHANGE THIS TO YOUR VAULT PATH
+# Parse command line arguments for the vault path
+parser = argparse.ArgumentParser(description="Map metadata from an Obsidian vault")
+parser.add_argument("vault_path", nargs="?", help="Path to the vault to scan")
+args = parser.parse_args()
+
+if args.vault_path:
+    vault_path = args.vault_path
+else:
+    parser.error("vault_path argument is required. Provide the path to your vault.")
 
 # Prepare output data
 metadata_log = []


### PR DESCRIPTION
## Summary
- allow vault path to be specified via command-line argument

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684206f7d6d08322ae3ee931e5a6a6dc