### PR TITLE
Add Encryption note to Cybersecurity section

### DIFF
--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Cybersecurity/Encryption.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Cybersecurity/Encryption.md
@@ -1,0 +1,46 @@
+---
+title: "Encryption"
+created: 2025-04-30
+type: note
+tags: [note, Cybersecurity]
+parent: "Cybersecurity"
+children: []
+---
+
+# Encryption
+
+## Summary
+Encryption is the process of converting readable information (plaintext) into an unreadable format (ciphertext) so that only authorized parties can access the original data. It is a cornerstone of data security for protecting communications, storage, and authentication mechanisms.
+
+## Core Concepts
+- **Plaintext**: Original data before encryption.
+- **Ciphertext**: Encoded data produced by an encryption algorithm.
+- **Keys**: Secret values used to encrypt and decrypt information.
+- **Symmetric vs. Asymmetric**: Whether the same key or different keys are used for encryption and decryption.
+- **Key Management**: Procedures for generating, distributing, and storing keys securely.
+
+## Types of Encryption
+### Symmetric Encryption
+Uses the same key for encryption and decryption. Examples include AES and DES.
+
+### Asymmetric Encryption
+Uses a public key to encrypt and a private key to decrypt. Examples include RSA and ECC.
+
+### Hash Functions
+While not strictly encryption, cryptographic hashes provide data integrity and are often used alongside encryption.
+
+## Applications
+- Secure web traffic via HTTPS
+- Protecting data at rest on disks or in databases
+- Authenticating users and devices
+- Safeguarding communications in messaging apps
+
+## Security Considerations
+- Key length and algorithm selection impact security strength.
+- Proper implementation and random number generation are critical.
+- [[Post-Quantum Cryptography]] aims to create algorithms resistant to quantum attacks.
+- [[Zero Knowledge Proofs]] enable verification without revealing secrets, complementing encryption schemes.
+
+## Related Topics
+- [[Post-Quantum Cryptography]]
+- [[Zero Knowledge Proofs]]


### PR DESCRIPTION
## Summary
- add Encryption note under Cybersecurity in Personal Encyclopedia
- includes YAML front matter, overview, key concepts, types, and links