### PR TITLE
Add macros note with automation index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Vault/System/Backend/Scripts/Plugins/draft-vaultos/test/Folder Scaffolding/node_
 
 # Ignore issue template archive
 .github/ISSUE_TEMPLATE.zip
+__pycache__/

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Automation and Scripting/Automation and Scripting.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Automation and Scripting/Automation and Scripting.md
@@ -1,0 +1,5 @@
+---
+tags: MOCs
+---
+```folder-index-content
+```

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Automation and Scripting/Macros/Macros.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Automation and Scripting/Macros/Macros.md
@@ -1,0 +1,77 @@
+---
+title: "Macros"
+created: 2025-06-08
+type: note
+tags: [note, macros]
+parent: "Automation and Scripting"
+children: []
+---
+
+# ⚙️ Macros
+
+## 🧭 Summary
+A macro is a rule or pattern that expands into a larger set of instructions. In computing, macros automate repetitive tasks by recording a series of actions or commands and executing them as a single command or trigger. They exist in software from spreadsheets to IDEs, text editors to operating systems.
+
+## 🧠 Core Concepts
+| Concept | Description |
+| --- | --- |
+| Macro | A predefined sequence of instructions that automate tasks. |
+| Trigger | The action or event that activates the macro (e.g., hotkey, command). |
+| Scripting Macro | A macro that includes conditional logic and variables (e.g., AutoHotkey). |
+| Recording Macro | A macro that records user actions without coding (e.g., Excel macros). |
+
+## 📍 Common Use Cases
+- 🔁 Automating repetitive text input or UI actions
+- 📈 Creating dynamic formulas and tasks in Excel
+- 🧪 Custom keyboard shortcuts in IDEs (e.g., VS Code, IntelliJ)
+- 🧠 Building workflows in Notion, Obsidian, and Zapier
+- ⌨️ Gaming macros for repeated keystrokes
+
+## 💬 Examples
+### 🧮 Excel Macro (VBA)
+```vb
+Sub HelloWorld()
+  MsgBox "Hello, world!"
+End Sub
+```
+
+### ⌨️ AutoHotkey Script
+```ahk
+::sig::Best regards,  
+Charlie
+```
+
+### 🧠 Templater Macro (Obsidian)
+```markdown
+<% tp.date.now("YYYY-MM-DD") %> — Daily reflection
+```
+
+## 🛠️ Popular Macro Tools & Platforms
+| Tool | Domain | Notes |
+| --- | --- | --- |
+| Excel VBA | Office productivity | Automates spreadsheets |
+| AutoHotkey | Windows desktop | Full scripting language |
+| Keyboard Maestro | macOS | GUI automation |
+| Templater (Obsidian) | Note-taking | Logic + dynamic templates |
+| Zapier / Make | Web workflows | No-code automation |
+| Elgato Stream Deck | Hardware | Macro pads for streamers and productivity nerds |
+
+## 🧱 Macros vs. Scripts
+| Feature | Macros | Scripts |
+| --- | --- | --- |
+| Code-based? | Optional | Always |
+| Designed for... | End-user automation | Programmable logic |
+| Use Case | Recording UI actions | Backend/system logic |
+
+## 🔐 Risks & Best Practices
+- Avoid macros from untrusted sources (can contain malicious code)
+- Comment and document your macros
+- Use naming conventions for clarity
+- Limit scope and permissions where possible (sandboxing)
+
+## 🧭 Related Topics
+- “Automation vs Scripting”
+- “Templater & Hotkeys in Obsidian”
+- “Command Line Aliases and Functions”
+- “Productivity Hacks in IDEs”
+- “Keyboard Shortcuts as Macros”


### PR DESCRIPTION
## Summary
- create folder `Automation and Scripting` and MOC note
- add detailed `Macros` page under Computing and AI
- ignore Python `__pycache__`
